### PR TITLE
fixing date for links

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 
-title: Welcome to DjangoCon US 2024
+title: Welcome to DjangoCon US 2025
 
 ## Archived version of homepage
 


### PR DESCRIPTION
I discovered that when linking to the website that it was showing 2024. 

![Screenshot from 2025-02-10 21-56-18](https://github.com/user-attachments/assets/a6a94553-1cd3-45f1-8205-6323f6b704f5)

