### PR TITLE
adding bluesky link icons

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -28,7 +28,8 @@
     "twitter": "https://x.com/djangocon",
     "x": "https://x.com/djangocon",
     "facebook": "https://www.facebook.com/djangoconus/",
-    "instagram": "https://www.instagram.com/djangocon/"
+    "instagram": "https://www.instagram.com/djangocon/",
+    "bluesky": "https://bsky.app/profile/djangocon.us/"
   },
 
   "sponsorsOrder": [

--- a/src/_includes/conf-social-share.html
+++ b/src/_includes/conf-social-share.html
@@ -8,6 +8,14 @@
     </a>
   </li>
   <li>
+    <a class="hover:text-social-bluesky" href="{{ site.social.bluesky }}">
+      <svg class="w-8 h-8 icon">
+        <title>Bluesky</title>
+        <use xlink:href="#bluesky-icon"></use>
+      </svg>
+    </a>
+  </li>
+  <li>
     <a class="hover:text-social-twitter" href="{{ site.social.twitter }}">
       <svg class="w-8 h-8 icon">
         <title>X (Formerly Twitter)</title>
@@ -28,6 +36,14 @@
       <svg class="w-8 h-8 icon">
         <title>Facebook</title>
         <use xlink:href="#facebook-icon"></use>
+      </svg>
+    </a>
+  </li>
+  <li>
+    <a class="hover:text-social-linkedin" href="{{ site.social.linkedin }}">
+      <svg class="w-8 h-8 icon">
+        <title>Facebook</title>
+        <use xlink:href="#linkedin-icon"></use>
       </svg>
     </a>
   </li>

--- a/src/_includes/home/landing-conf-home.html
+++ b/src/_includes/home/landing-conf-home.html
@@ -15,6 +15,7 @@
       <p class="flex flex-wrap justify-center my-6 gap-4">
         <a href="{{ site.mailing_list }}" class="button ">Mailing list for updates</a>
         <a href="{{ site.social.mastodon }}" class="button">Follow us on Mastodon</a>
+        <a href="{{ site.social.bluesky }}" class="button">Follow us on Bluesky</a>
         <a href="{{ site.cfp_application }}" class="button">Submit a Talk Proposal</a>
       </p>
 


### PR DESCRIPTION
Added Bluesky Icon with link for the footer.

Added a follow us on Bluesky button. I am not sure if we want this, but I am thinking that we wanted to push traffic to Mastodon and Bluesky. Mastodon button is already present. 