### PR TITLE
fix for achieve misspelled

### DIFF
--- a/src/about/index.html
+++ b/src/about/index.html
@@ -118,7 +118,7 @@ description: |
       <section class="relative flex flex-col gap-4 p-6 bg-white lg:pt-10 card-effect-2">
         <img src="/assets/img/theme/icons/Heart.svg" alt="A heart." class="w-16 h-16 icon" />
         <h3 class="text-lg font-bold lg:text-2xl font-heading" id="commitment-to-diversity">Commitment to Diversity</h3>
-        <p class="lg:text-lg">It is a core aim of DjangoCon US 2025 to encourage diversity, enforce our Code of Conduct, and make our event as inclusive and accessible as possible. <strong><a href="/opportunity-grants/" class="link">Opportunity Grants</a></strong> help us acheive this goal.</p>
+        <p class="lg:text-lg">It is a core aim of DjangoCon US 2025 to encourage diversity, enforce our Code of Conduct, and make our event as inclusive and accessible as possible. <strong><a href="/opportunity-grants/" class="link">Opportunity Grants</a></strong> help us achieve this goal.</p>
       </section>
 
       <section class="relative flex flex-col gap-4 p-6 bg-white lg:pt-10 card-effect-3">


### PR DESCRIPTION
Fixed a typo.

Before 

![Screenshot 2025-04-25 at 11 58 41 AM](https://github.com/user-attachments/assets/5519eb89-a616-415d-ad4e-e5240777b306)

After

![image](https://github.com/user-attachments/assets/486abfc5-8cad-4e05-87d2-44b91ac9a0d5)
