### PR TITLE
feat(news): add post about how djangocon US selects proposals

### DIFF
--- a/src/_content/posts/proposal-selection.md
+++ b/src/_content/posts/proposal-selection.md
@@ -2,10 +2,8 @@
 author: Programs Team
 category: General
 published_datetime: 2025-05-01 04:55:00
-title: "How DjangoCon US Selects Proposals"
+title: "How DjangoCon US Selects Talk Proposals"
 ---
-
-[Submit your proposal for DjangoCon US 2025](https://pretalx.com/djangocon-us-2025/cfp) — **CFP is open until May 4!**
 
 The DjangoCon US schedule is always highly anticipated. But how does it all come together? 
 
@@ -16,7 +14,7 @@ The journey from an open Call for Proposals (CFP) to the final lineup of talks, 
 ## 2025 Program Timeline
 _*Subject to change depending on the number of submissions and other factors._
 
-- **CFP Deadline Extension**: May 4
+- ~**CFP Deadline Extension**: May 4~
 - **Reviewer Deadline**: May 18
 - **Panel Finalization**: June 6
 - **Speaker Notifications**: June 8
@@ -76,6 +74,4 @@ Keynote announcements typically occur in **June or July** after the talk schedul
 
 
 DjangoCon US is more than a conference. It's a reflection of the community that makes Django special. Every part of our program, from anonymous reviews to committee deliberations and keynote invitations, is rooted in care and intentionality. We aim to surface new voices, avoid bias, and curate a meaningful and engaging conference experience.
-
-There's still time to participate in the conference! [Submit your talk or tutorial proposal before May 4.](https://pretalx.com/djangocon-us-2025/cfp)
 

--- a/src/_content/posts/proposal-selection.md
+++ b/src/_content/posts/proposal-selection.md
@@ -1,0 +1,81 @@
+---
+author: Programs Team
+category: General
+published_datetime: 2025-05-01 04:55:00
+title: "How DjangoCon US Selects Proposals"
+---
+
+[Submit your proposal for DjangoCon US 2025](https://pretalx.com/djangocon-us-2025/cfp) — **CFP is open until May 4!**
+
+The DjangoCon US schedule is always highly anticipated. But how does it all come together? 
+
+
+The journey from an open Call for Proposals (CFP) to the final lineup of talks, tutorials, and keynote sessions is a thoughtful and collaborative process designed to foster fairness and showcase the best of the Django community.
+
+
+## 2025 Program Timeline
+_*Subject to change depending on the number of submissions and other factors._
+
+- **CFP Deadline Extension**: May 4
+- **Reviewer Deadline**: May 18
+- **Panel Finalization**: June 6
+- **Speaker Notifications**: June 8
+- **Schedule Announcement**: mid-June
+- **Keynote Announcements**: June-July
+
+
+## Call for Proposals Opens
+The community proposes talks and tutorials by filling in the [CFP](https://pretalx.com/djangocon-us-2025/cfp). We use [Pretalx](https://pretalx.com/p/about/), a platform designed for conferences that support **anonymous review** and **structured scoring**. Thus, each submission is evaluated based on content, not the speaker's name or background.
+
+## Anonymization & Code of Conduct Compliance
+Once the CFP closes, the program team carefully reviews every submission to:
+- **Anonymize** any unique identifying details. 
+- **Ensure Code of Conduct compliance**.
+
+This step is crucial for fair and unbiased reviewing. The person responsible for anonymization does not participate in the anonymous review process.
+
+## Community Reviews Talks
+Once proposals are anonymized, we open the review process to a team of volunteer reviewers from the community. They follow guidelines that promote consistency, fairness, and awareness of potential bias.
+
+
+## Reviewer Guidelines Emphasize:
+- **Focusing on content**, not style, grammar, or speaker identity
+- **Leaving a comment for all "No" ratings** (and encouraged for "Maybe")
+- **Flagging known proposals** using a BIAS: prefix and skipping scoring
+- **Identifying any remaining personal info**
+- **Disclosing conflicts of interest**
+
+Reviewers have until **May 18** to provide feedback on as many proposals as possible.
+
+
+## Committee Deliberation & Selection
+Once the reviews are in, the committee will lift the anonymization and meet to create the final schedule. At this stage, we look at:
+- **Review scores and written feedback**
+- **Topic coverage** (e.g., avoiding repetition like six HTMX talks)
+- **Speaker diversity** (especially elevating underrepresented voices and first-time speakers)
+- **Company representation** (ensuring one organization doesn't dominate)
+- **Prior speaking history and organizer involvement**
+
+
+Some talks are accepted or declined based on strong consensus. The most difficult decisions often revolve around the final handful of slots, which we may reserve in case of scheduling conflicts or withdrawals.
+The speakers will receive notifications about the decision on or before **June 8**.
+
+
+At this point, we evaluate the suggested panellists and hosts who will participate in the last conference day and the discussion topic.
+
+## Keynote Speaker Selection
+Keynote speakers follow a separate, invitation-based process that begins well before the CFP closes. As outlined by previous DjangoCon US Chair Drew Winstel in [his blog post](https://winstel.dev/2024/10/20/what-makes-a-good-dcus-keynote/), we look for individuals who bring:
+
+- **Emotional resonance** and the ability to connect and engage with the audience
+- **A compelling, unique perspective—reflective**, funny, challenging, or inspiring
+- **Stage presence**, though extensive speaking experience isn't required
+- **Representation of the community**, especially those who've contributed significantly or brought underrepresented viewpoints to the forefront
+
+
+Keynote announcements typically occur in **June or July** after the talk schedule is shared.
+
+
+DjangoCon US is more than a conference. It's a reflection of the community that makes Django special. Every part of our program, from anonymous reviews to committee deliberations and keynote invitations, is rooted in care and intentionality. We aim to surface new voices, avoid bias, and curate a meaningful and engaging conference experience.
+
+There's still time to participate in the conference! [Submit your talk or tutorial proposal before May 4.](https://pretalx.com/djangocon-us-2025/cfp)
+


### PR DESCRIPTION
- Blog about How DjangoCon US selects proposals 


## List View

![Screenshot from 2025-05-01 17-12-26](https://github.com/user-attachments/assets/bc7f049b-5d04-4e7c-a3e1-7a33c3b17791)


## Content

![Screenshot from 2025-05-01 17-12-02](https://github.com/user-attachments/assets/b03fdb5c-ccf6-4c4e-9256-bb9eec6c767e)
