### PR TITLE
:memo: add venue and room sharing

### DIFF
--- a/src/_includes/nav.html
+++ b/src/_includes/nav.html
@@ -17,6 +17,12 @@
     </li>
     <!-- <li><a href="/schedule/">Schedule</a></li> -->
     <li>
+    <a href="/venue/" data-menu-trigger aria-haspopup="true" aria-expanded="false">Venue</a>
+    <ul data-menu-list class="hidden site-nav-menu">
+      <li><a href="/room-sharing/" role="menuitem">Room Sharing</a></li>
+    </ul>
+    </li>
+    <li>
     <a href="/venue/" data-menu-trigger aria-haspopup="true" aria-expanded="false">Speaking</a>
     <ul data-menu-list class="hidden site-nav-menu">
       <li><a href="/speaking/" role="menuitem">Speaking at DjangoCon US</a></li>

--- a/src/room-sharing.html
+++ b/src/room-sharing.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-draft: true
+draft: false
 title: Room Sharing
 description: Share a room or ride
 ---
@@ -20,9 +20,10 @@ description: Share a room or ride
     <div class="prose lg:prose-lg">
 
 
-      <p>Do you want to share a room at <a href="/venue/#hotel">one of the hotels</a> with other attendees, or do you have local accommodation available? Do you want to drive to DjangoCon US from Charlotte, Greensboro, Raleigh, or other relatively nearby cities?</p>
+      <!-- <p>Do you want to share a room at <a href="/venue/#hotel">one of the hotels</a> with other attendees, or do you have local accommodation available? Do you want to drive to DjangoCon US from Charlotte, Greensboro, Raleigh, or other relatively nearby cities?</p> -->
+      <p>Do you want to share a room at one of the hotels with other attendees, or do you have local accommodation available? Do you want to drive to DjangoCon US from Milwaukee, Indianapolis, St. Louis, or other relatively nearby cities? </p>
 
-      <p>We have a <a href="https://docs.google.com/spreadsheets/d/1487pyAR--sN3dpSDrDQWAQmxq25BgHIVM99xZIHRpp4/edit?usp=sharing">Google sheet</a> just for you! There are tabs for people who already have room reservations and are looking for roommates, who haven't yet booked anything, who live locally and want to offer their homes as accommodation, and who will be driving to Durham and need car buddies.</p>
+      <p>We have a <a href="https://docs.google.com/spreadsheets/d/1vwaCBE89mcsD7napVQV-pJvQoP50SR5SXnMiMdJ6byE/edit?usp=sharing">Google sheet</a> just for you! There are tabs for people who already have room reservations and are looking for roommates, who haven't yet booked anything, who live locally and want to offer their homes as accommodation, and who will be driving to Chicago and need car buddies.</p>
       <p>If you're looking for a room, list your contact information along with:</p>
 
       <ul>
@@ -39,7 +40,7 @@ description: Share a room or ride
 
       <p><b>Caution:</b> Room and ride sharing arrangements are the responsibilities of the individual parties involved. DEFNA, DSF, and DjangoCon US staff take no responsibility, and cannot be involved in any disputes.</p>
 
-      <a class="button" href="https://docs.google.com/spreadsheets/d/1487pyAR--sN3dpSDrDQWAQmxq25BgHIVM99xZIHRpp4/edit?usp=sharing">Share a Room or Ride (spreadsheet information)</a>
+      <a class="button" href="https://docs.google.com/spreadsheets/d/1vwaCBE89mcsD7napVQV-pJvQoP50SR5SXnMiMdJ6byE/edit?usp=sharing">Share a Room or Ride (spreadsheet information)</a>
 
     </div>
   </div>


### PR DESCRIPTION
Add venue dropdown and update room sharing page to reflect change in new city. 

Future note: Once Welcome to Chicago becomes active link the hotels to room sharing.