### PR TITLE
:calendar: Update registration closing to avoid layout conflict

### DIFF
--- a/src/_content/schedule/manual.yaml
+++ b/src/_content/schedule/manual.yaml
@@ -64,7 +64,7 @@
   start_datetime: 2025-09-09 08:00:00-05:00
   title: Continental Breakfast
   track: t0
-- end_datetime: 2025-09-09 17:30:00-05:00
+- end_datetime: 2025-09-09 17:00:00-05:00
   permalink: null
   room: In front of Room A
   start_datetime: 2025-09-09 08:00:00-05:00
@@ -118,7 +118,7 @@
   start_datetime: 2025-09-10 08:00:00-05:00
   title: Continental Breakfast
   track: t0
-- end_datetime: 2025-09-10 17:30:00-05:00
+- end_datetime: 2025-09-10 17:00:00-05:00
   permalink: null
   room: In front of Room A
   start_datetime: 2025-09-10 08:00:00-05:00

--- a/tools/models.py
+++ b/tools/models.py
@@ -407,7 +407,7 @@ MANUAL_SCHEDULE_ENTRIES = [
         ),
         end_datetime=pydatetime.datetime.combine(
             constants.TALK_DAY_2,
-            pydatetime.time(17, 30),
+            pydatetime.time(17),
             tzinfo=constants.CONFERENCE_TZ,
         ),
         group="break",
@@ -565,7 +565,7 @@ MANUAL_SCHEDULE_ENTRIES = [
         ),
         end_datetime=pydatetime.datetime.combine(
             constants.TALK_DAY_3,
-            pydatetime.time(17, 30),
+            pydatetime.time(17),
             tzinfo=constants.CONFERENCE_TZ,
         ),
         group="break",


### PR DESCRIPTION
This fixes the oddity of having all 4 on the same row.

Before:
<img width="1221" height="273" alt="image" src="https://github.com/user-attachments/assets/7d8e49ae-4eb8-410d-a6f8-575a284eb1df" />

After:
<img width="1265" height="345" alt="image" src="https://github.com/user-attachments/assets/59a1747d-45ea-4ffd-98ea-45ba7e60f412" />
