### PR TITLE
Fix incorrect website for Carson Gross

### DIFF
--- a/src/_content/presenters/carson-gross.md
+++ b/src/_content/presenters/carson-gross.md
@@ -10,7 +10,6 @@ social:
     instagram: null
     mastodon: null
     twitter: htmx_org
-    website: https://www.mostlypython.com
 ---
 
 Carson Gross is a computer programmer most widely known for creating htmx, an alternative front end library emphasizing the hypermedia architecture of the web.  He teaches computer science, including compilers, web development & databases at Montana State University, where he also heads the HyperMedia Research Group.  He has published two books: 'Hypermedia Systems', a book on the concepts of hypermedia and htmx, and 'The Grug Brained Developer', a short book on software engineering concepts.  He lives in Bozeman, Montana with his family.


### PR DESCRIPTION
That’s the site of Eric Matthes