### PR TITLE
:bug: Stop skipping first day; render its sessions

### DIFF
--- a/src/youtube-talks.html
+++ b/src/youtube-talks.html
@@ -20,47 +20,45 @@ permalink: /speaking/youtube/
   <div class="wrapper grid grid-cols-1 gap-4">
 
     {% for day in collections.sessionsByDateAndTime %}
-      {% if forloop.index0 > 0 %}
-        {% for slot in day[1] %}
-          {% for session in slot.sessions %}
-            {% if session.presenter_slugs %}
-              <div class="event-byline grid grid-cols-1 gap-2">
-                <div class="flex items-center justify-between gap-2 mx-2">
-                  <h4 class="flex-grow mr-2">
-                    <span>{{ day[0] | formatDateTime: "LLL d " }}{{ slot.start | formatDateTime: "h:mm aaa" }} EDT -</span>
-                    <span id="copy-{{ session.title|slugify }}-title">
-                      {{ session.title }} with
-                      {% for presenter_slug in session.presenter_slugs %}
-                        {% assign presenter = collections.presenters | find:presenter_slug %}
-                        {% if not forloop.first %} and {% endif %}
-                        {{ presenter.data.name }}
-                      {% endfor %}
-                    </span>
-                  </h4>
-                  {% if post.video_url %}
-                    <div class="btn bg-teal-200 border-solid border-2 border-grey-800 rounded-lg px-2 py-1 whitespace-nowrap" >
-                      <a href="{{ post.video_url }}">View on YouTube</a>
-                    </div>
-                  {% endif %}
-                  <button class="btn bg-teal-200 border-solid border-2 border-grey-800 rounded-lg px-2 py-1 whitespace-nowrap" data-clipboard-action="copy" data-clipboard-target="#copy-{{ session.title|slugify }}-title">
-                    Copy to clipboard
-                  </button>
-                </div>
+      {% for slot in day[1] %}
+        {% for session in slot.sessions %}
+          {% if session.presenter_slugs %}
+            <div class="event-byline grid grid-cols-1 gap-2">
+              <div class="flex items-center justify-between gap-2 mx-2">
+                <h4 class="flex-grow mr-2">
+                  <span>{{ day[0] | formatDateTime: "LLL d " }}{{ slot.start | formatDateTime: "h:mm aaa" }} EDT -</span>
+                  <span id="copy-{{ session.title|slugify }}-title">
+                    {{ session.title }} with
+                    {% for presenter_slug in session.presenter_slugs %}
+                      {% assign presenter = collections.presenters | find:presenter_slug %}
+                      {% if not forloop.first %} and {% endif %}
+                      {{ presenter.data.name }}
+                    {% endfor %}
+                  </span>
+                </h4>
+                {% if post.video_url %}
+                  <div class="btn bg-teal-200 border-solid border-2 border-grey-800 rounded-lg px-2 py-1 whitespace-nowrap" >
+                    <a href="{{ post.video_url }}">View on YouTube</a>
+                  </div>
+                {% endif %}
+                <button class="btn bg-teal-200 border-solid border-2 border-grey-800 rounded-lg px-2 py-1 whitespace-nowrap" data-clipboard-action="copy" data-clipboard-target="#copy-{{ session.title|slugify }}-title">
+                  Copy to clipboard
+                </button>
+              </div>
 
-                <div class="relative">
+              <div class="relative">
 <textarea rows="10" id="copy-{{ session.title|slugify }}" class="w-full pr-32">
 {% include "youtube-copy-and-paste.html", session:session %}
 </textarea>
-                  <button class="btn bg-teal-200 border-solid border-2 border-grey-800 rounded-lg px-2 py-1 absolute top-2 right-2" data-clipboard-action="copy" data-clipboard-target="#copy-{{ session.title|slugify }}">
-                    Copy to clipboard
-                  </button>
-                </div>
+                <button class="btn bg-teal-200 border-solid border-2 border-grey-800 rounded-lg px-2 py-1 absolute top-2 right-2" data-clipboard-action="copy" data-clipboard-target="#copy-{{ session.title|slugify }}">
+                  Copy to clipboard
+                </button>
               </div>
-              <hr>
-            {% endif %}
-          {% endfor %}
+            </div>
+            <hr>
+          {% endif %}
         {% endfor %}
-      {% endif %}
+      {% endfor %}
     {% endfor %}
 
   </div>


### PR DESCRIPTION
I think because our schedule started with a day of tutorials last year, we hard coded the template to skip the first/zeroth day. 

This is live https://2025.djangocon.us/speaking/youtube/ 

<img width="1315" height="656" alt="Screenshot 2025-10-28 at 12 38 39 PM" src="https://github.com/user-attachments/assets/4b1ba507-c187-4fd6-b3f9-1fb88dfdb769" />

This is the fix: 

<img width="1320" height="670" alt="Screenshot 2025-10-28 at 12 39 46 PM" src="https://github.com/user-attachments/assets/cc188751-cc83-4a98-9969-6a732a2e6463" />
