### PR TITLE
Remove the video url field from the title for Kattni's talk

### DIFF
--- a/src/_content/schedule/talks/the-source-of-change-bettering-online-open-source-communities-can-begin-with-you.md
+++ b/src/_content/schedule/talks/the-source-of-change-bettering-online-open-source-communities-can-begin-with-you.md
@@ -10,9 +10,8 @@ tags:
 - open-source
 - Inclusion
 - Community
-title: 'The Source of Change: Bettering Online Open Source Communities Can Begin with
+title: 'The Source of Change: Bettering Online Open Source Communities Can Begin with You'
 video_url: FYxbVioCX1Q
-  You'
 track: t0
 ---
 


### PR DESCRIPTION
It's rendering on the web as "The Source of Change: Bettering Online Open Source Communities Can Begin with video_url: FYxbVioCX1Q You"