### PR TITLE
Add the schedule link to the nav menu for post-conference usage.

### DIFF
--- a/src/_includes/nav.html
+++ b/src/_includes/nav.html
@@ -41,6 +41,7 @@
       <li><a href="{{site.sponsorship_prospectus}}" target="_blank" role="menuitem">Sponsorship Prospectus</a></li>
     </ul>
   </li>
+  <li><a href="/schedule/">Schedule</a></li>
   <li><a href="/news/">News</a></li>
 </ul>
 <a href="{{ site.ticket_link }}" target="_blank" class="button button-lg">Buy Tickets</a>


### PR DESCRIPTION
There's value in showing people what the talk order was. It provides a place for me to ctrl+f the title or speaker to find the talk, allows me another way to remember how the conference went and lets the next year's attendees see how the past year was organized. I also like linking to the djangocon.us domain rather than youtube when possible.

### Screenshots

The new schedule link can be seen in the upper right corner.

<img width="1261" height="804" alt="Screenshot from 2026-05-05 19-39-13" src="https://github.com/user-attachments/assets/857b5c7d-16d0-4792-a2cf-f7456c86bd92" />
